### PR TITLE
Namespacing all events and plugins to prevent interference with others

### DIFF
--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -2,14 +2,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\CatalogInventory\Observer\AddInventoryDataObserver">
-        <plugin name="after_product_load" type="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad" />
+        <plugin name="EcomDev_ProductDataPreLoader::after_product_load" type="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad" />
     </type>
 
     <type name="Magento\Catalog\Model\ProductRepository">
-        <plugin name="fix_store_id_of_get_by_id" type="EcomDev\ProductDataPreLoader\Plugin\FixMissingStoreIdInProductRepository" />
+        <plugin name="EcomDev_ProductDataPreLoader::fix_store_id_of_get_by_id" type="EcomDev\ProductDataPreLoader\Plugin\FixMissingStoreIdInProductRepository" />
     </type>
 
     <type name="Magento\Quote\Model\ResourceModel\Quote\Item\Collection">
-        <plugin name="preserve_quote_for_item_collection" type="EcomDev\ProductDataPreLoader\Plugin\StoreShoppingCartIntoObserver"  />
+        <plugin name="EcomDev_ProductDataPreLoader::preserve_quote_for_item_collection" type="EcomDev\ProductDataPreLoader\Plugin\StoreShoppingCartIntoObserver"  />
     </type>
 </config>

--- a/src/etc/frontend/events.xml
+++ b/src/etc/frontend/events.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="catalog_product_collection_load_after">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ListCollectionAfterLoad" />
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ListCollectionAfterLoad" />
     </event>
 
     <event name="sales_quote_item_collection_products_after_load">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\CartCollectionAfterLoad" />
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\CartCollectionAfterLoad" />
     </event>
 
     <event name="catalog_product_load_after">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad"/>
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad"/>
     </event>
 </config>

--- a/src/etc/webapi_rest/di.xml
+++ b/src/etc/webapi_rest/di.xml
@@ -2,14 +2,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\CatalogInventory\Observer\AddInventoryDataObserver">
-        <plugin name="after_product_load" type="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad" />
+        <plugin name="EcomDev_ProductDataPreLoader::after_product_load" type="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad" />
     </type>
 
     <type name="Magento\Catalog\Model\ProductRepository">
-        <plugin name="fix_store_id_of_get_by_id" type="EcomDev\ProductDataPreLoader\Plugin\FixMissingStoreIdInProductRepository" />
+        <plugin name="EcomDev_ProductDataPreLoader::fix_store_id_of_get_by_id" type="EcomDev\ProductDataPreLoader\Plugin\FixMissingStoreIdInProductRepository" />
     </type>
 
     <type name="Magento\Quote\Model\ResourceModel\Quote\Item\Collection">
-        <plugin name="preserve_quote_for_item_collection" type="EcomDev\ProductDataPreLoader\Plugin\StoreShoppingCartIntoObserver"  />
+        <plugin name="EcomDev_ProductDataPreLoader::preserve_quote_for_item_collection" type="EcomDev\ProductDataPreLoader\Plugin\StoreShoppingCartIntoObserver"  />
     </type>
 </config>

--- a/src/etc/webapi_rest/events.xml
+++ b/src/etc/webapi_rest/events.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="catalog_product_collection_load_after">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ListCollectionAfterLoad" />
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ListCollectionAfterLoad" />
     </event>
 
     <event name="core_collection_abstract_load_after">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\CartCollectionAfterLoad" />
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\CartCollectionAfterLoad" />
     </event>
 
     <event name="catalog_product_load_after">
-        <observer name="preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad"/>
+        <observer name="EcomDev_ProductDataPreLoader::preload_data_with_pre_loaders" instance="EcomDev\ProductDataPreLoader\Observer\ProductAfterLoad"/>
     </event>
 </config>


### PR DESCRIPTION
Hey @IvanChepurnyi ,

Great Meet Magento talk!  Had a quick look at your module and noticed plugins/events weren't namespaced meaning (presuming I haven't got the wrong end of the stick) they could potentially interfere with other plugins/events with the same name, figured I'd just make a quick PR to sort this