### PR TITLE
Feature: expose row id in case of commerce

### DIFF
--- a/src/DataService/MagentoProductWrapper.php
+++ b/src/DataService/MagentoProductWrapper.php
@@ -50,6 +50,14 @@ class MagentoProductWrapper implements ProductWrapper
     /**
      * {@inheritDoc}
      */
+    public function getRowId(): int
+    {
+        return (int) $this->product->getRowId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function isType(string ...$type): bool
     {
         return in_array($this->product->getTypeId(), $type, true);

--- a/src/DataService/ProductWrapper.php
+++ b/src/DataService/ProductWrapper.php
@@ -29,6 +29,13 @@ interface ProductWrapper
     public function getId(): int;
 
     /**
+     * Returns product Row ID if available
+     *
+     * @return int
+     */
+    public function getRowId(): int;
+    
+    /**
      * Check if product is of a type
      *
      * @param string ...$type


### PR DESCRIPTION
For projects working on commerce it's required to use row_id instead of entity_id when joining data from super link tables for example.